### PR TITLE
Fix redeployment of local deployed clab

### DIFF
--- a/action_plugins/simulation.py
+++ b/action_plugins/simulation.py
@@ -520,9 +520,7 @@ class ActionModule(ActionBase):
                 
                 filename = sim_dir+node+"_"+sim_topology_file_name+".clab.yml"
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
-                # Keep the topology used by the running local lab. The deploy
-                # tasks use it to remove nodes that may no longer be present
-                # in the newly generated topology.
+                # Keep the topology because it is needed later to destroy the lab
                 if containerlab_deploy_local and os.path.exists(filename):
                     shutil.copy2(filename, f"{filename}.previous")
                 with open(filename, "w") as fh:

--- a/action_plugins/simulation.py
+++ b/action_plugins/simulation.py
@@ -520,6 +520,11 @@ class ActionModule(ActionBase):
                 
                 filename = sim_dir+node+"_"+sim_topology_file_name+".clab.yml"
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
+                # Keep the topology used by the running local lab. The deploy
+                # tasks use it to remove nodes that may no longer be present
+                # in the newly generated topology.
+                if containerlab_deploy_local and os.path.exists(filename):
+                    shutil.copy2(filename, f"{filename}.previous")
                 with open(filename, "w") as fh:
                     fh.write(result)
 
@@ -615,7 +620,7 @@ class ActionModule(ActionBase):
                         if not containerlab_deploy_local:
                             shutil.copytree(bind_path, sim_dir+node+"/"+containerlab_linux_kind_bind_dir)
                         else:
-                            shutil.copytree(bind_path, sim_dir+containerlab_linux_kind_bind_dir)
+                            shutil.copytree(bind_path, sim_dir+containerlab_linux_kind_bind_dir, dirs_exist_ok=True)
             
             if not containerlab_deploy_local:
                 # Package all files needed for each simulation host if it is not run locally from the simulation directory

--- a/tasks/create_avd_node_files.yml
+++ b/tasks/create_avd_node_files.yml
@@ -9,9 +9,7 @@
     - "{{ containerlab_dir }}"
   delegate_to: localhost
   run_once: true
-  # For a local deployment this directory contains the topology of the
-  # running lab. Keep it so the action plugin can preserve that topology for
-  # the destroy step during a re-deployment.
+  # For a local deployment we need to retain to destroy the lab later
   when: not (containerlab_deploy_local | default(false))
 
 - name: Include device intended structure configuration variables

--- a/tasks/create_avd_node_files.yml
+++ b/tasks/create_avd_node_files.yml
@@ -2,13 +2,17 @@
 # tasks file for avd nodes
 
 - name: Remove local containerlab output directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   loop:
     - "{{ containerlab_dir }}"
   delegate_to: localhost
   run_once: true
+  # For a local deployment this directory contains the topology of the
+  # running lab. Keep it so the action plugin can preserve that topology for
+  # the destroy step during a re-deployment.
+  when: not (containerlab_deploy_local | default(false))
 
 - name: Include device intended structure configuration variables
   delegate_to: localhost

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -22,9 +22,19 @@
     clab_workdir: "{% if containerlab_deploy_local | default(false) %}{{ containerlab_dir }}{% else %}{{ ansible_facts.env.PWD }}/{{ containerlab_labname }}{% endif %}"
 
 - name: Check if there is already a topology file with the same name
-  stat:
+  ansible.builtin.stat:
     path: "{{ clab_workdir }}/{{inventory_hostname}}_{{ sim_topology_file_name }}.clab.yml"
   register: stat_result
+
+- name: Check for the topology from the running local lab
+  ansible.builtin.stat:
+    path: "{{ clab_workdir }}/{{ inventory_hostname }}_{{ sim_topology_file_name }}.clab.yml.previous"
+  register: previous_topology_result
+  when: containerlab_deploy_local | default(false)
+
+- name: Determine topology file to use for lab destruction
+  ansible.builtin.set_fact:
+    clab_destroy_topology_file: "{{ inventory_hostname }}_{{ sim_topology_file_name }}.clab.yml{{ '.previous' if containerlab_deploy_local | default(false) and previous_topology_result.stat.exists else '' }}"
 
 - name: Destroy the lab using containerlab in a container
   become: true
@@ -38,15 +48,25 @@
     --pid='host' \
     -v {{ clab_workdir_parent }}:{{ clab_workdir_parent }} \
     -w {{ clab_workdir }} \
-    ghcr.io/srl-labs/clab clab destroy -t {{inventory_hostname}}_{{ sim_topology_file_name }}.clab.yml --cleanup "
+    ghcr.io/srl-labs/clab clab destroy -t {{ clab_destroy_topology_file }} --cleanup "
   when: containerlab_mode == 'container' and stat_result.stat.exists and containerlab_deploy_on_hosts
 
 - name: Destroy the lab using installed containerlab
   become: true
-  command: "clab destroy -t {{inventory_hostname}}_{{ sim_topology_file_name }}.clab.yml --cleanup{% if containerlab_runtime is defined and containerlab_runtime != 'docker' %} --runtime {{ containerlab_runtime }}{% endif %}"
+  command: "clab destroy -t {{ clab_destroy_topology_file }} --cleanup{% if containerlab_runtime is defined and containerlab_runtime != 'docker' %} --runtime {{ containerlab_runtime }}{% endif %}"
   args:
     chdir: "{{ clab_workdir }}"
   when: containerlab_mode == 'installed' and stat_result.stat.exists and containerlab_deploy_on_hosts
+
+- name: Remove the topology backup after local lab destruction
+  ansible.builtin.file:
+    path: "{{ clab_workdir }}/{{ clab_destroy_topology_file }}"
+    state: absent
+  when:
+    - containerlab_deploy_local | default(false)
+    - previous_topology_result.stat.exists
+    - stat_result.stat.exists
+    - containerlab_deploy_on_hosts
 
 - name: Delete vxlan interfaces which were used by the old lab
   become: true


### PR DESCRIPTION
Fix is only for the mode "containerlab_deploy_local".
1. 
When this mode is activated the output_dir will not be deleted in the playbook task "create_avd_node_files.yml". This is because we need the topology file later to destroy existing labs. Therefore we need to allow merging of the directories in the simulation.py.
2. As the topology file could be changed we need do backup to old version to a ".previous" one to ensure the destroyment of the lab. The backup is created in "simulation.py" and afterwards deleted in the deploy task.
